### PR TITLE
Improve inheritance list

### DIFF
--- a/src/organize.ts
+++ b/src/organize.ts
@@ -121,8 +121,14 @@ export function prepareForFile(solidityFilePath: string): IObjectViewData {
             }
         },
         InheritanceSpecifier: (node: any) => {
+            let currentInheritance = data.inheritance;
+            if (currentInheritance !== undefined) {
+                currentInheritance.push(node.baseName);
+            } else {
+                currentInheritance = [node.baseName];
+            }
             data = {
-                inheritance: node.baseName,
+                inheritance: currentInheritance,
                 ...data,
             };
         },

--- a/test/contracts/inheritance/BarbaryLion.sol
+++ b/test/contracts/inheritance/BarbaryLion.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.6;
+
+import "./Lion.sol";
+
+/// Yes, there are different Lions, and the Barbary is a special one.
+/// https://animalsake.com/different-species-of-lions-with-pictures
+contract BarbaryLion is Lion {
+    constructor() public {
+        //
+    }
+}

--- a/test/contracts/inheritance/Dog.sol
+++ b/test/contracts/inheritance/Dog.sol
@@ -1,9 +1,0 @@
-pragma solidity ^0.5.6;
-
-import "./Mammal.sol";
-
-contract Dog is Mammal {
-    constructor() public {
-        //
-    }
-}

--- a/test/contracts/inheritance/IMammal.sol
+++ b/test/contracts/inheritance/IMammal.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.5.6;
+
+interface IMammal {
+    function size() external view returns(uint256);
+}

--- a/test/contracts/inheritance/Lion.sol
+++ b/test/contracts/inheritance/Lion.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.6;
+
+import "./Mammal.sol";
+import "./Quadruped.sol";
+import "./WildLife.sol";
+
+contract Lion is Mammal, Quadruped, WildLife {
+    constructor() public {
+        //
+    }
+}

--- a/test/contracts/inheritance/Lion.sol
+++ b/test/contracts/inheritance/Lion.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.5.6;
 
-import "./Mammal.sol";
 import "./Quadruped.sol";
 import "./WildLife.sol";
 
-contract Lion is Mammal, Quadruped, WildLife {
+contract Lion is Quadruped, WildLife {
     constructor() public {
         //
     }

--- a/test/contracts/inheritance/Mammal.sol
+++ b/test/contracts/inheritance/Mammal.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.5.6;
 
 import "./Animal.sol";
+import "./IMammal.sol";
 
-contract Mammal is Animal {
+contract Mammal is IMammal, Animal {
     constructor() public {
         //
     }

--- a/test/contracts/inheritance/Quadruped.sol
+++ b/test/contracts/inheritance/Quadruped.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.6;
+
+import "./Mammal.sol";
+
+contract Quadruped is Mammal {
+    constructor() public {
+        //
+    }
+}

--- a/test/contracts/inheritance/WildLife.sol
+++ b/test/contracts/inheritance/WildLife.sol
@@ -1,8 +1,7 @@
 pragma solidity ^0.5.6;
 
-import "./Dog.sol";
 
-contract Yorkshire is Dog {
+contract WildLife {
     constructor() public {
         //
     }

--- a/test/html/folder.spec.js
+++ b/test/html/folder.spec.js
@@ -74,8 +74,10 @@ describe('Render HTML Page - Complete folder', () => {
             'Ignore',
             'Animal',
             'Mammal',
-            'Dog',
-            'Yorkshire',
+            'IMammal',
+            'Lion',
+            'Quadruped',
+            'WildLife',
         ];
         await page.waitFor('ul#contracts-treeview li a');
         const cards = await page.$$('ul#contracts-treeview li a');

--- a/test/html/folder.spec.js
+++ b/test/html/folder.spec.js
@@ -76,6 +76,7 @@ describe('Render HTML Page - Complete folder', () => {
             'Mammal',
             'IMammal',
             'Lion',
+            'BarbaryLion',
             'Quadruped',
             'WildLife',
         ];

--- a/test/html/inheritance.spec.js
+++ b/test/html/inheritance.spec.js
@@ -95,6 +95,7 @@ describe('Render HTML Page - Inheritance (Lion)', () => {
         // should also, not list the ignored ones!
         const cardsNames = [
             'Quadruped',
+            'WildLife',
         ];
         await page.waitFor('aside ul#inheritance li a');
         const cards = await page.$$('aside ul#inheritance li a');

--- a/test/html/inheritance.spec.js
+++ b/test/html/inheritance.spec.js
@@ -9,7 +9,7 @@ describe('Render HTML Page - Inheritance (Barbary Lion)', () => {
     beforeAll(async () => {
         jest.setTimeout(20000);
         // first render
-        generate('html', [], './docs/test-html-inheritance', './test/contracts/inheritance/BarbaryLion.sol');
+        generate('html', [], './docs/test-html-inheritance', './test/contracts/inheritance/BarbaryLion.sol', './test', 'xyz', process.cwd());
         // now let's test the result
         // open the browser
         browser = await puppeteer.launch();
@@ -62,7 +62,7 @@ describe('Render HTML Page - Inheritance (Lion)', () => {
     beforeAll(async () => {
         jest.setTimeout(20000);
         // first render
-        generate('html', [], './docs/test-html-inheritance', './test/contracts/inheritance/Lion.sol');
+        generate('html', [], './docs/test-html-inheritance', './test/contracts/inheritance/Lion.sol', './test', 'xyz', process.cwd());
         // now let's test the result
         // open the browser
         browser = await puppeteer.launch();

--- a/test/html/inheritance.spec.js
+++ b/test/html/inheritance.spec.js
@@ -1,0 +1,108 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+const { generate } = require('../../dist/index');
+
+describe('Render HTML Page - Inheritance (Barbary Lion)', () => {
+    let browser;
+    let page;
+
+    beforeAll(async () => {
+        jest.setTimeout(20000);
+        // first render
+        generate('html', [], './docs/test-html-inheritance', './test/contracts/inheritance/BarbaryLion.sol');
+        // now let's test the result
+        // open the browser
+        browser = await puppeteer.launch();
+        // open a new page
+        page = await browser.newPage();
+        // and navigate to the rendered page
+        await page.goto(path.join('file://', process.cwd(), '/docs/test-html-inheritance/BarbaryLion.html'));
+    });
+
+    afterAll(async () => {
+        // close the browser
+        await browser.close();
+    });
+
+    /**
+     * The main contract being shown should be named "BarbaryLion"
+     */
+    test('should be named "BarbaryLion"', async (done) => {
+        await page.waitFor('h1#contractName');
+        const element = await page.$('h1#contractName');
+        const text = await page.evaluate((e) => e.textContent, element);
+        expect(text).toBe('BarbaryLion');
+        done();
+    });
+
+    /**
+     * All the contracts inherited should be listed in the side menu
+     */
+    test('should have all inherited contracts listed (side menu)', async (done) => {
+        // should also, not list the ignored ones!
+        const cardsNames = [
+            'Lion',
+        ];
+        await page.waitFor('aside ul#inheritance li a');
+        const cards = await page.$$('aside ul#inheritance li a');
+        for (let c = 0; c < cards.length; c += 1) {
+            // eslint-disable-next-line no-await-in-loop
+            const text = await page.evaluate((e) => e.textContent, cards[c]);
+            expect(cardsNames).toContain(text);
+        }
+        done();
+    });
+});
+
+
+describe('Render HTML Page - Inheritance (Lion)', () => {
+    let browser;
+    let page;
+
+    beforeAll(async () => {
+        jest.setTimeout(20000);
+        // first render
+        generate('html', [], './docs/test-html-inheritance', './test/contracts/inheritance/Lion.sol');
+        // now let's test the result
+        // open the browser
+        browser = await puppeteer.launch();
+        // open a new page
+        page = await browser.newPage();
+        // and navigate to the rendered page
+        await page.goto(path.join('file://', process.cwd(), '/docs/test-html-inheritance/Lion.html'));
+    });
+
+    afterAll(async () => {
+        // close the browser
+        await browser.close();
+    });
+
+    /**
+     * The main contract being shown should be named "BarbaryLion"
+     */
+    test('should be named "Lion"', async (done) => {
+        await page.waitFor('h1#contractName');
+        const element = await page.$('h1#contractName');
+        const text = await page.evaluate((e) => e.textContent, element);
+        expect(text).toBe('Lion');
+        done();
+    });
+
+    /**
+     * All the contracts inherited should be listed in the side menu
+     */
+    test('should have all inherited contracts listed (side menu)', async (done) => {
+        // should also, not list the ignored ones!
+        const cardsNames = [
+            'Quadruped',
+        ];
+        await page.waitFor('aside ul#inheritance li a');
+        const cards = await page.$$('aside ul#inheritance li a');
+        for (let c = 0; c < cards.length; c += 1) {
+            // eslint-disable-next-line no-await-in-loop
+            const text = await page.evaluate((e) => e.textContent, cards[c]);
+            expect(cardsNames).toContain(text);
+        }
+        done();
+    });
+});


### PR DESCRIPTION
fixes https://github.com/HQ20/soldoc/issues/48#issuecomment-578529917

Indeed, it is only showing the first inherited contract. This PR is here to fix it. New example contracts were added, and new tests as well.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] new tests
- [ ] keep or improve the tests coverage
- [ ] documentation is changed or added

### Description of change
On the right side menu, the inherited contracts/interfaces are listed, but currently, only the first one.
If a contract inherits two or more contracts or interfaces, only the first one is shown, and in cases where there are multiple levels of inheritance, they are also not listed.
